### PR TITLE
Add Caja management view and mock services

### DIFF
--- a/src/components/CajaView.vue
+++ b/src/components/CajaView.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="container mt-5">
+    <h1>Caja</h1>
+    <div v-if="!caja || !caja.abierta" class="mb-3">
+      <label class="form-label">Monto inicial</label>
+      <input v-model.number="montoInicial" type="number" class="form-control" />
+      <button class="btn btn-primary mt-2" @click="abrirCaja">Abrir Caja</button>
+    </div>
+    <div v-else class="mb-3">
+      <p><strong>Fecha Apertura:</strong> {{ formatDate(caja.fechaApertura) }}</p>
+      <p><strong>Saldo Actual:</strong> {{ caja.saldoActual }}</p>
+      <div class="button-group mb-2">
+        <button class="btn btn-danger me-2" @click="cerrarCaja">Cerrar Caja</button>
+      </div>
+      <div class="mt-3">
+        <input v-model="descripcion" class="form-control mb-2" placeholder="Descripción" />
+        <input v-model.number="montoMovimiento" type="number" class="form-control mb-2" placeholder="Monto" />
+        <button class="btn btn-success me-2" @click="registrarIngreso">Registrar Cobro</button>
+        <button class="btn btn-warning" @click="registrarEgreso">Registrar Pago</button>
+      </div>
+    </div>
+    <h2 class="mt-4">Movimientos</h2>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Fecha</th>
+          <th>Descripción</th>
+          <th>Monto</th>
+          <th>Tipo</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(mov, index) in movimientos" :key="index">
+          <td>{{ formatDate(mov.fecha) }}</td>
+          <td>{{ mov.descripcion }}</td>
+          <td>{{ mov.monto }}</td>
+          <td>{{ mov.tipo }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import CajaService from '@/services/CajaServiceMock';
+
+export default {
+  name: 'CajaView',
+  data() {
+    return {
+      caja: null,
+      movimientos: [],
+      montoInicial: 0,
+      descripcion: '',
+      montoMovimiento: 0
+    };
+  },
+  async mounted() {
+    this.caja = await CajaService.obtenerEstado();
+    this.movimientos = await CajaService.obtenerMovimientos();
+  },
+  methods: {
+    async abrirCaja() {
+      this.caja = await CajaService.abrirCaja(this.montoInicial);
+      this.movimientos = await CajaService.obtenerMovimientos();
+    },
+    async cerrarCaja() {
+      await CajaService.cerrarCaja();
+      this.caja = null;
+      this.movimientos = [];
+    },
+    async registrarIngreso() {
+      if (!this.descripcion || !this.montoMovimiento) return;
+      await CajaService.registrarMovimiento({
+        descripcion: this.descripcion,
+        monto: this.montoMovimiento,
+        tipo: 'ingreso'
+      });
+      this.movimientos = await CajaService.obtenerMovimientos();
+      this.caja = await CajaService.obtenerEstado();
+      this.descripcion = '';
+      this.montoMovimiento = 0;
+    },
+    async registrarEgreso() {
+      if (!this.descripcion || !this.montoMovimiento) return;
+      await CajaService.registrarMovimiento({
+        descripcion: this.descripcion,
+        monto: this.montoMovimiento,
+        tipo: 'egreso'
+      });
+      this.movimientos = await CajaService.obtenerMovimientos();
+      this.caja = await CajaService.obtenerEstado();
+      this.descripcion = '';
+      this.montoMovimiento = 0;
+    },
+    formatDate(fecha) {
+      return fecha ? new Date(fecha).toLocaleString() : '';
+    }
+  }
+};
+</script>
+
+<style scoped>
+.button-group {
+  margin-bottom: 1rem;
+}
+</style>
+

--- a/src/models/Caja.js
+++ b/src/models/Caja.js
@@ -1,0 +1,32 @@
+export default class Caja {
+  constructor({ abierta = false, saldoInicial = 0, saldoActual = 0, fechaApertura = null, fechaCierre = null } = {}) {
+    this.abierta = abierta;
+    this.saldoInicial = saldoInicial;
+    this.saldoActual = saldoActual;
+    this.fechaApertura = fechaApertura;
+    this.fechaCierre = fechaCierre;
+    this.movimientos = [];
+  }
+
+  abrir(monto) {
+    this.abierta = true;
+    this.saldoInicial = monto;
+    this.saldoActual = monto;
+    this.fechaApertura = new Date().toISOString();
+    this.movimientos = [];
+  }
+
+  cerrar() {
+    this.abierta = false;
+    this.fechaCierre = new Date().toISOString();
+  }
+
+  registrarMovimiento(mov) {
+    this.movimientos.push(mov);
+    if (mov.tipo === 'ingreso') {
+      this.saldoActual += mov.monto;
+    } else {
+      this.saldoActual -= mov.monto;
+    }
+  }
+}

--- a/src/models/MovimientoCaja.js
+++ b/src/models/MovimientoCaja.js
@@ -1,0 +1,8 @@
+export default class MovimientoCaja {
+  constructor({ descripcion = '', monto = 0, tipo = 'ingreso', fecha = null } = {}) {
+    this.descripcion = descripcion;
+    this.monto = monto;
+    this.tipo = tipo; // 'ingreso' o 'egreso'
+    this.fecha = fecha || new Date().toISOString();
+  }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,7 @@ import FacturaView from '../components/Factura.vue'; // Importa la pantalla de F
 import NotaDeRemision from '../components/NotaDeRemision.vue'; // Importa la pantalla de NotaDeRemision
 import ListarComprobantes from '../components/ListarComprobantes.vue'; // Importa la pantalla de ListarComprobantes
 import UserManagement from '../components/UserManagement.vue'; // Importa UserManagement
+import CajaView from '../components/CajaView.vue';
 
 const routes = [
   {
@@ -39,6 +40,11 @@ const routes = [
     path: '/listar-comprobantes',
     name: 'ListarComprobantes',
     component: ListarComprobantes
+  },
+  {
+    path: '/caja',
+    name: 'Caja',
+    component: CajaView
   },
   {
     path: '/user-management',

--- a/src/services/CajaServiceMock.js
+++ b/src/services/CajaServiceMock.js
@@ -1,0 +1,62 @@
+import Caja from '@/models/Caja';
+import MovimientoCaja from '@/models/MovimientoCaja';
+
+class CajaServiceMock {
+  constructor() {
+    this.cajaActual = null;
+  }
+
+  async abrirCaja(montoInicial) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        this.cajaActual = new Caja();
+        this.cajaActual.abrir(montoInicial);
+        resolve(this.cajaActual);
+      }, 300);
+    });
+  }
+
+  async cerrarCaja() {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        if (this.cajaActual) {
+          this.cajaActual.cerrar();
+          this.cajaActual = null;
+        }
+        resolve();
+      }, 300);
+    });
+  }
+
+  async registrarMovimiento({ descripcion, monto, tipo }) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        if (!this.cajaActual) {
+          resolve(null);
+          return;
+        }
+        const movimiento = new MovimientoCaja({ descripcion, monto, tipo });
+        this.cajaActual.registrarMovimiento(movimiento);
+        resolve(movimiento);
+      }, 300);
+    });
+  }
+
+  async obtenerEstado() {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(this.cajaActual);
+      }, 300);
+    });
+  }
+
+  async obtenerMovimientos() {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(this.cajaActual ? [...this.cajaActual.movimientos] : []);
+      }, 300);
+    });
+  }
+}
+
+export default new CajaServiceMock();


### PR DESCRIPTION
## Summary
- add `CajaView` component to manage cash register opening, closing and movements
- create `Caja` and `MovimientoCaja` models
- implement `CajaServiceMock` for in-memory storage
- register Caja route in the router

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm run serve` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68562e1ff3cc8329badc32f63713144b