### PR TITLE
Add Caja module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,9 @@ npm run build
 npm run lint
 ```
 
+## Módulo de Caja
+
+Una vez ejecutada la aplicación (`npm run serve`), ingresa a la ruta `/caja` desde el navegador o usa el enlace **Caja** del menú principal para administrar la apertura, cierre y movimientos de caja.
+
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -41,6 +41,11 @@
                 <i class="bi bi-file-text"></i> Notas de Remisión
               </router-link>
             </li>
+            <li class="nav-item">
+              <router-link class="nav-link" to="/caja">
+                <i class="bi bi-cash"></i> Caja
+              </router-link>
+            </li>
             <li class="nav-item admin-only">
               <router-link class="nav-link" to="/user-management">
                 <i class="bi bi-person-gear"></i> User Management

--- a/src/models/Caja.js
+++ b/src/models/Caja.js
@@ -1,0 +1,16 @@
+// src/models/Caja.js
+export default class Caja {
+  constructor({ id = null, fechaApertura = null, fechaCierre = null, montoApertura = 0, montoCierre = 0, estado = 'cerrada', movimientos = [] } = {}) {
+    this.id = id;
+    this.fechaApertura = fechaApertura;
+    this.fechaCierre = fechaCierre;
+    this.montoApertura = montoApertura;
+    this.montoCierre = montoCierre;
+    this.estado = estado; // 'abierta' o 'cerrada'
+    this.movimientos = movimientos;
+  }
+
+  agregarMovimiento(tipo, monto, descripcion) {
+    this.movimientos.push({ tipo, monto, descripcion, fecha: new Date() });
+  }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ import ProveedoresView from '@/views/ProveedoresView.vue';
 import PermisosView from '@/views/PermisosView.vue';
 import ListarComprobantesNT from '@/views/ListarComprobantesNT.vue';
 import RolesView from '@/views/RolesView.vue';
+import CajaView from '@/views/CajaView.vue';
 
 const routes = [
   {
@@ -105,6 +106,11 @@ const routes = [
     path: '/listar-proveedores',
     name: 'ListarProveedores',
     component: ProveedoresView
+  },
+  {
+    path: '/caja',
+    name: 'Caja',
+    component: CajaView
   }
 ];
 

--- a/src/services/CajaService.js
+++ b/src/services/CajaService.js
@@ -1,0 +1,30 @@
+// src/services/CajaService.js
+import apiService from './apiService';
+
+class CajaService {
+  constructor() {
+    this.baseUrl = `${process.env.VUE_APP_API_BASE_URL}/api/cajas`;
+  }
+
+  abrirCaja(data) {
+    return apiService.post(`${this.baseUrl}/abrir`, data);
+  }
+
+  cerrarCaja(id, data) {
+    return apiService.post(`${this.baseUrl}/${id}/cerrar`, data);
+  }
+
+  obtenerCajaActual() {
+    return apiService.get(`${this.baseUrl}/actual`);
+  }
+
+  registrarMovimiento(id, movimiento) {
+    return apiService.post(`${this.baseUrl}/${id}/movimientos`, movimiento);
+  }
+
+  listar() {
+    return apiService.get(this.baseUrl);
+  }
+}
+
+export default new CajaService();

--- a/src/services/CajaServiceMock.js
+++ b/src/services/CajaServiceMock.js
@@ -1,0 +1,57 @@
+// src/services/CajaServiceMock.js
+import Caja from '@/models/Caja';
+
+class CajaServiceMock {
+  constructor() {
+    this.caja = new Caja();
+  }
+
+  async abrirCaja(data) {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        this.caja = new Caja({
+          id: Date.now(),
+          fechaApertura: new Date().toISOString(),
+          montoApertura: data.monto_apertura,
+          estado: 'abierta',
+          movimientos: []
+        });
+        resolve({ data: this.caja });
+      }, 200);
+    });
+  }
+
+  async cerrarCaja(id, data) {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        this.caja.fechaCierre = new Date().toISOString();
+        this.caja.montoCierre = data.monto_cierre;
+        this.caja.estado = 'cerrada';
+        resolve({ data: this.caja });
+      }, 200);
+    });
+  }
+
+  async obtenerCajaActual() {
+    return new Promise(resolve => {
+      setTimeout(() => resolve({ data: this.caja }), 200);
+    });
+  }
+
+  async registrarMovimiento(id, movimiento) {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        this.caja.agregarMovimiento(movimiento.tipo, movimiento.monto, movimiento.descripcion);
+        resolve({ data: this.caja });
+      }, 200);
+    });
+  }
+
+  async listar() {
+    return new Promise(resolve => {
+      setTimeout(() => resolve({ data: [this.caja] }), 200);
+    });
+  }
+}
+
+export default new CajaServiceMock();

--- a/src/views/CajaView.vue
+++ b/src/views/CajaView.vue
@@ -1,0 +1,139 @@
+<template>
+  <AppNavbar />
+  <div class="container mt-5">
+    <AppHeader title="Control de Caja">
+      <template #buttons>
+        <button v-if="caja.estado === 'cerrada'" class="btn btn-primary" @click="mostrarAbrirModal">Abrir Caja</button>
+        <button v-else class="btn btn-danger" @click="mostrarCerrarModal">Cerrar Caja</button>
+      </template>
+    </AppHeader>
+
+    <div v-if="caja.estado === 'abierta'">
+      <p><strong>Fecha de Apertura:</strong> {{ caja.fechaApertura }}</p>
+      <p><strong>Monto Apertura:</strong> {{ caja.montoApertura }}</p>
+      <h3 class="mt-4">Movimientos</h3>
+      <ul class="list-group mb-3">
+        <li v-for="(m, index) in caja.movimientos" :key="index" class="list-group-item">
+          {{ m.fecha }} - {{ m.tipo }} - {{ m.monto }} - {{ m.descripcion }}
+        </li>
+      </ul>
+      <div class="mb-3">
+        <input v-model="nuevoMovimiento.descripcion" placeholder="Descripción" class="form-control mb-2" />
+        <input v-model.number="nuevoMovimiento.monto" type="number" placeholder="Monto" class="form-control mb-2" />
+        <select v-model="nuevoMovimiento.tipo" class="form-select mb-2">
+          <option value="ingreso">Ingreso</option>
+          <option value="egreso">Egreso</option>
+        </select>
+        <button class="btn btn-success" @click="registrarMovimiento">Agregar Movimiento</button>
+      </div>
+    </div>
+
+    <div class="modal fade" id="abrirModal" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Abrir Caja</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <input v-model.number="montoApertura" type="number" class="form-control" placeholder="Monto de apertura" />
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="button" class="btn btn-primary" @click="abrirCaja">Abrir</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal fade" id="cerrarModal" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Cerrar Caja</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <input v-model.number="montoCierre" type="number" class="form-control" placeholder="Monto de cierre" />
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="button" class="btn btn-danger" @click="cerrarCaja">Cerrar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { Modal } from 'bootstrap';
+import AppNavbar from '@/components/AppNavbar.vue';
+import AppHeader from '@/components/AppHeader.vue';
+import CajaService from '@/services/CajaService';
+
+export default {
+  name: 'CajaView',
+  components: { AppNavbar, AppHeader },
+  data() {
+    return {
+      caja: { estado: 'cerrada', movimientos: [] },
+      montoApertura: 0,
+      montoCierre: 0,
+      nuevoMovimiento: { tipo: 'ingreso', monto: 0, descripcion: '' }
+    };
+  },
+  methods: {
+    async cargarCajaActual() {
+      try {
+        const res = await CajaService.obtenerCajaActual();
+        this.caja = res.data || { estado: 'cerrada', movimientos: [] };
+      } catch (err) {
+        console.error('Error obteniendo caja actual', err);
+      }
+    },
+    mostrarAbrirModal() {
+      const modal = new Modal(document.getElementById('abrirModal'));
+      modal.show();
+    },
+    mostrarCerrarModal() {
+      const modal = new Modal(document.getElementById('cerrarModal'));
+      modal.show();
+    },
+    async abrirCaja() {
+      try {
+        await CajaService.abrirCaja({ monto_apertura: this.montoApertura });
+        this.cargarCajaActual();
+        Modal.getInstance(document.getElementById('abrirModal')).hide();
+      } catch (err) {
+        console.error('Error abriendo caja', err);
+      }
+    },
+    async cerrarCaja() {
+      try {
+        await CajaService.cerrarCaja(this.caja.id, { monto_cierre: this.montoCierre });
+        this.cargarCajaActual();
+        Modal.getInstance(document.getElementById('cerrarModal')).hide();
+      } catch (err) {
+        console.error('Error cerrando caja', err);
+      }
+    },
+    async registrarMovimiento() {
+      if (this.caja.estado !== 'abierta') return;
+      try {
+        await CajaService.registrarMovimiento(this.caja.id, this.nuevoMovimiento);
+        this.nuevoMovimiento = { tipo: 'ingreso', monto: 0, descripcion: '' };
+        this.cargarCajaActual();
+      } catch (err) {
+        console.error('Error registrando movimiento', err);
+      }
+    }
+  },
+  mounted() {
+    this.cargarCajaActual();
+  }
+};
+</script>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- define Caja model with basic fields and method
- add CajaService with API calls and mock alternative
- implement CajaView with open/close and movement list
- register Caja route and navbar link
- document how to access the module

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563749b23c83299462f61562a2444b