### PR TITLE
Implement caja module with store

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,9 @@ npm run build
 npm run lint
 ```
 
+## Módulo de Caja
+
+Una vez ejecutada la aplicación (`npm run serve`), ingresa a la ruta `/caja` desde el navegador o usa el enlace **Caja** del menú principal. La vista emplea un store de Pinia para gestionar el estado de la caja y los movimientos. Desde allí podrás abrir o cerrar la caja mediante modales fijos y registrar movimientos.
+
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "bootstrap-icons": "^1.11.3",
     "core-js": "^3.8.3",
     "vue": "^3.2.13",
-    "vue-router": "^4.4.5"
+    "vue-router": "^4.4.5",
+    "pinia": "^2.1.7"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -41,6 +41,11 @@
                 <i class="bi bi-file-text"></i> Notas de Remisión
               </router-link>
             </li>
+            <li class="nav-item">
+              <router-link class="nav-link" to="/caja">
+                <i class="bi bi-cash"></i> Caja
+              </router-link>
+            </li>
             <li class="nav-item admin-only">
               <router-link class="nav-link" to="/user-management">
                 <i class="bi bi-person-gear"></i> User Management

--- a/src/components/CloseCajaModal.vue
+++ b/src/components/CloseCajaModal.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="modal fade" :class="{ show: showModal }" :style="{ display: showModal ? 'block' : 'none' }" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Cerrar Caja</h5>
+          <button type="button" class="btn-close" @click="close"></button>
+        </div>
+        <div class="modal-body">
+          <input v-model.number="monto" type="number" class="form-control" placeholder="Monto de cierre" />
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" @click="close">Cancelar</button>
+          <button type="button" class="btn btn-danger" @click="emitClose">Cerrar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-backdrop fade show" v-if="showModal"></div>
+</template>
+
+<script>
+export default {
+  name: 'CloseCajaModal',
+  emits: ['update:showModal', 'close'],
+  props: { showModal: { type: Boolean, default: false } },
+  data() {
+    return { monto: 0 };
+  },
+  methods: {
+    close() {
+      this.$emit('update:showModal', false);
+    },
+    emitClose() {
+      this.$emit('close', this.monto);
+      this.monto = 0;
+      this.close();
+    }
+  }
+};
+</script>
+
+<style scoped>
+</style>

--- a/src/components/OpenCajaModal.vue
+++ b/src/components/OpenCajaModal.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="modal fade" :class="{ show: showModal }" :style="{ display: showModal ? 'block' : 'none' }" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Abrir Caja</h5>
+          <button type="button" class="btn-close" @click="close"></button>
+        </div>
+        <div class="modal-body">
+          <input v-model.number="monto" type="number" class="form-control" placeholder="Monto de apertura" />
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" @click="close">Cancelar</button>
+          <button type="button" class="btn btn-primary" @click="emitOpen">Abrir</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-backdrop fade show" v-if="showModal"></div>
+</template>
+
+<script>
+export default {
+  name: 'OpenCajaModal',
+  emits: ['update:showModal', 'open'],
+  props: {
+    showModal: { type: Boolean, default: false }
+  },
+  data() {
+    return { monto: 0 };
+  },
+  methods: {
+    close() {
+      this.$emit('update:showModal', false);
+    },
+    emitOpen() {
+      this.$emit('open', this.monto);
+      this.monto = 0;
+      this.close();
+    }
+  }
+};
+</script>
+
+<style scoped>
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue';
+import { createPinia } from 'pinia';
 import App from './App.vue';
 import router from './router'; // Importa el router
 
@@ -11,6 +12,8 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 
 // Inicializa la aplicación
 const app = createApp(App);
+const pinia = createPinia();
 
 app.use(router);
+app.use(pinia);
 app.mount('#app');

--- a/src/models/Caja.js
+++ b/src/models/Caja.js
@@ -1,0 +1,16 @@
+// src/models/Caja.js
+export default class Caja {
+  constructor({ id = null, fechaApertura = null, fechaCierre = null, montoApertura = 0, montoCierre = 0, estado = 'cerrada', movimientos = [] } = {}) {
+    this.id = id;
+    this.fechaApertura = fechaApertura;
+    this.fechaCierre = fechaCierre;
+    this.montoApertura = montoApertura;
+    this.montoCierre = montoCierre;
+    this.estado = estado; // 'abierta' o 'cerrada'
+    this.movimientos = movimientos;
+  }
+
+  agregarMovimiento(tipo, monto, descripcion) {
+    this.movimientos.push({ tipo, monto, descripcion, fecha: new Date() });
+  }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ import ProveedoresView from '@/views/ProveedoresView.vue';
 import PermisosView from '@/views/PermisosView.vue';
 import ListarComprobantesNT from '@/views/ListarComprobantesNT.vue';
 import RolesView from '@/views/RolesView.vue';
+import CajaView from '@/views/CajaView.vue';
 
 const routes = [
   {
@@ -105,6 +106,11 @@ const routes = [
     path: '/listar-proveedores',
     name: 'ListarProveedores',
     component: ProveedoresView
+  },
+  {
+    path: '/caja',
+    name: 'Caja',
+    component: CajaView
   }
 ];
 

--- a/src/services/CajaService.js
+++ b/src/services/CajaService.js
@@ -1,0 +1,30 @@
+// src/services/CajaService.js
+import apiService from './apiService';
+
+class CajaService {
+  constructor() {
+    this.baseUrl = `${process.env.VUE_APP_API_BASE_URL}/api/caja`;
+  }
+
+  abrirCaja() {
+    return apiService.post(`${this.baseUrl}/open`);
+  }
+
+  cerrarCaja() {
+    return apiService.post(`${this.baseUrl}/close`);
+  }
+
+  obtenerCajaActual() {
+    return apiService.get(`${this.baseUrl}/actual`);
+  }
+
+  registrarMovimiento(movimiento) {
+    return apiService.post(`${this.baseUrl}/movimientos`, movimiento);
+  }
+
+  obtenerMovimientos() {
+    return apiService.get(`${this.baseUrl}/movimientos`);
+  }
+}
+
+export default new CajaService();

--- a/src/stores/cajaStore.js
+++ b/src/stores/cajaStore.js
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia';
+import CajaService from '@/services/CajaService';
+
+export const useCajaStore = defineStore('caja', {
+  state: () => ({
+    movimientos: [],
+    isOpen: false,
+    loading: false
+  }),
+  actions: {
+    async fetchMovimientos() {
+      try {
+        this.loading = true;
+        const { data } = await CajaService.obtenerMovimientos();
+        this.movimientos = data || [];
+      } finally {
+        this.loading = false;
+      }
+    },
+    async registrarMovimiento(movimiento) {
+      await CajaService.registrarMovimiento(movimiento);
+      await this.fetchMovimientos();
+    },
+    async abrirCaja() {
+      await CajaService.abrirCaja();
+      this.isOpen = true;
+    },
+    async cerrarCaja() {
+      await CajaService.cerrarCaja();
+      this.isOpen = false;
+    }
+  }
+});

--- a/src/views/CajaView.vue
+++ b/src/views/CajaView.vue
@@ -1,0 +1,122 @@
+<template>
+  <AppNavbar />
+  <div class="container mt-5">
+    <AppHeader title="Caja">
+      <template #buttons>
+        <AppButton v-if="!store.isOpen" @click="showOpenModal = true">Abrir Caja</AppButton>
+        <AppButton v-else variant="danger" @click="showCloseModal = true">Cerrar Caja</AppButton>
+      </template>
+    </AppHeader>
+
+    <div class="mb-4">
+      <p><strong>Estado:</strong> {{ store.isOpen ? 'abierta' : 'cerrada' }}</p>
+    </div>
+
+    <div v-if="store.isOpen" class="mb-4">
+      <h4>Registrar Movimiento</h4>
+      <div class="row g-2 align-items-end">
+        <div class="col-md-3">
+          <select v-model="nuevoMovimiento.tipo" class="form-select">
+            <option value="Cobro">Cobro</option>
+            <option value="Pago">Pago</option>
+            <option value="Depósito">Depósito</option>
+            <option value="Retiro">Retiro</option>
+          </select>
+        </div>
+        <div class="col-md-3">
+          <input v-model.number="nuevoMovimiento.monto" type="number" class="form-control" placeholder="Monto" />
+        </div>
+        <div class="col-md-3">
+          <select v-model="nuevoMovimiento.formaPago" class="form-select">
+            <option value="Efectivo">Efectivo</option>
+          </select>
+        </div>
+        <div class="col-md-2">
+          <AppButton variant="success" class="w-100" @click="registrarMovimiento">Agregar</AppButton>
+        </div>
+      </div>
+    </div>
+
+    <h3 class="mt-4">Movimientos</h3>
+    <div class="mb-2">
+      <input v-model="search" class="form-control" placeholder="Buscar" />
+    </div>
+    <AppTable :headers="['ID', 'Fecha', 'Tipo', 'Forma de Pago', 'Monto']">
+      <tr v-for="m in filteredMovimientos" :key="m.id">
+        <td>{{ m.id }}</td>
+        <td>{{ formatDate(m.fecha) }}</td>
+        <td>{{ m.tipo }}</td>
+        <td>{{ m.formaPago }}</td>
+        <td>{{ m.monto }}</td>
+      </tr>
+    </AppTable>
+
+    <OpenCajaModal v-model:showModal="showOpenModal" @open="abrirCaja" />
+    <CloseCajaModal v-model:showModal="showCloseModal" @close="cerrarCaja" />
+  </div>
+</template>
+
+<script>
+import AppNavbar from '@/components/AppNavbar.vue';
+import AppHeader from '@/components/AppHeader.vue';
+import AppButton from '@/components/AppButton.vue';
+import AppTable from '@/components/AppTable.vue';
+import OpenCajaModal from '@/components/OpenCajaModal.vue';
+import CloseCajaModal from '@/components/CloseCajaModal.vue';
+import { useCajaStore } from '@/stores/cajaStore';
+
+export default {
+  name: 'CajaView',
+  components: {
+    AppNavbar,
+    AppHeader,
+    AppButton,
+    AppTable,
+    OpenCajaModal,
+    CloseCajaModal
+  },
+  setup() {
+    const store = useCajaStore();
+    return { store };
+  },
+  data() {
+    return {
+      nuevoMovimiento: { tipo: 'Cobro', monto: 0, formaPago: 'Efectivo' },
+      showOpenModal: false,
+      showCloseModal: false,
+      search: ''
+    };
+  },
+  computed: {
+    filteredMovimientos() {
+      const term = this.search.toLowerCase();
+      return this.store.movimientos.filter(m =>
+        m.tipo.toLowerCase().includes(term) ||
+        m.formaPago.toLowerCase().includes(term)
+      );
+    }
+  },
+  methods: {
+    formatDate(date) {
+      return date ? new Date(date).toLocaleString() : '';
+    },
+    async abrirCaja(amount) {
+      await this.store.abrirCaja();
+    },
+    async cerrarCaja(amount) {
+      await this.store.cerrarCaja();
+    },
+    async registrarMovimiento() {
+      if (!this.store.isOpen) return;
+      await this.store.registrarMovimiento(this.nuevoMovimiento);
+      this.nuevoMovimiento = { tipo: 'Cobro', monto: 0, formaPago: 'Efectivo' };
+    }
+  },
+  mounted() {
+    this.store.fetchMovimientos();
+  }
+};
+</script>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- add Pinia dependency and initialize store
- create cajaStore for global cash-box state
- update CajaService endpoints
- refactor CajaView to use the store and new movement form
- document Pinia usage in README

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563749b23c83299462f61562a2444b